### PR TITLE
Renames channels to connectors, adds connector communication via channels

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -5,7 +5,6 @@ import "fmt"
 import "os"
 import "net"
 import "bufio"
-import "strconv"
 
 import "github.com/UniversityRadioYork/ury-rapid-go/baps3protocol"
 
@@ -17,10 +16,10 @@ type Channel struct {
 	buf       *bufio.Reader
 }
 
-func InitChannel(port int) *Channel {
+func InitChannel(hostport string) *Channel {
 	c := new(Channel)
 	c.tokeniser = baps3protocol.NewTokeniser()
-	conn, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/connector.go
+++ b/connector.go
@@ -7,6 +7,7 @@ import "net"
 import "bufio"
 
 import "github.com/UniversityRadioYork/ury-rapid-go/baps3protocol"
+import "github.com/UniversityRadioYork/ury-rapid-go/util"
 
 type Connector struct {
 	state     string
@@ -65,7 +66,7 @@ func (c *Connector) Run() {
 						os.Exit(1)
 					}
 					c.time = time
-					c.resCh <- PrettyDuration(time)
+					c.resCh <- util.PrettyDuration(time)
 				case "STATE":
 					c.state = line[1]
 					c.resCh <- line[1]

--- a/connector.go
+++ b/connector.go
@@ -8,7 +8,7 @@ import "bufio"
 
 import "github.com/UniversityRadioYork/ury-rapid-go/baps3protocol"
 
-type Channel struct {
+type Connector struct {
 	state     string
 	time      time.Duration
 	tokeniser *baps3protocol.Tokeniser
@@ -18,8 +18,8 @@ type Channel struct {
 	reqCh     <-chan string
 }
 
-func InitChannel(hostport string, reqCh <-chan string, resCh chan<- string) *Channel {
-	c := new(Channel)
+func InitConnector(hostport string, reqCh <-chan string, resCh chan<- string) *Connector {
+	c := new(Connector)
 	c.tokeniser = baps3protocol.NewTokeniser()
 	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
@@ -33,7 +33,7 @@ func InitChannel(hostport string, reqCh <-chan string, resCh chan<- string) *Cha
 	return c
 }
 
-func (c *Channel) Run() {
+func (c *Connector) Run() {
 	lineCh := make(chan [][]string, 3)
 	errCh := make(chan error)
 

--- a/connector.go
+++ b/connector.go
@@ -18,9 +18,15 @@ type Connector struct {
 	reqCh     <-chan string
 }
 
-func InitConnector(hostport string, reqCh <-chan string, resCh chan<- string) *Connector {
+func InitConnector(reqCh <-chan string, resCh chan<- string) *Connector {
 	c := new(Connector)
 	c.tokeniser = baps3protocol.NewTokeniser()
+	c.resCh = resCh
+	c.reqCh = reqCh
+	return c
+}
+
+func (c *Connector) Connect(hostport string) {
 	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
 		fmt.Println(err)
@@ -28,9 +34,6 @@ func InitConnector(hostport string, reqCh <-chan string, resCh chan<- string) *C
 	}
 	c.conn = conn
 	c.buf = bufio.NewReader(c.conn)
-	c.resCh = resCh
-	c.reqCh = reqCh
-	return c
 }
 
 func (c *Connector) Run() {

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ func main() {
 	ticker := time.NewTicker(time.Second)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)
-	c1 := InitChannel(1350)
-	c2 := InitChannel(1351)
+	c1 := InitChannel("localhost:1350")
+	c2 := InitChannel("localhost:1351")
 	go c1.Run()
 	go c2.Run()
 	for {

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ func main() {
 	c1ResCh := make(chan string)
 	c2ReqCh := make(chan string)
 	c2ResCh := make(chan string)
-	c1 := InitChannel("localhost:1350", c1ReqCh, c1ResCh)
-	c2 := InitChannel("localhost:1351", c2ReqCh, c2ResCh)
+	c1 := InitConnector("localhost:1350", c1ReqCh, c1ResCh)
+	c2 := InitConnector("localhost:1351", c2ReqCh, c2ResCh)
 	go c1.Run()
 	go c2.Run()
 	for {

--- a/main.go
+++ b/main.go
@@ -1,27 +1,28 @@
 package main
 
-import "time"
 import "os"
 import "os/signal"
 import "syscall"
 import "fmt"
-import "math"
 
 func main() {
-	ticker := time.NewTicker(time.Second)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)
-	c1 := InitChannel("localhost:1350")
-	c2 := InitChannel("localhost:1351")
+	c1ReqCh := make(chan string)
+	c1ResCh := make(chan string)
+	c2ReqCh := make(chan string)
+	c2ResCh := make(chan string)
+	c1 := InitChannel("localhost:1350", c1ReqCh, c1ResCh)
+	c2 := InitChannel("localhost:1351", c2ReqCh, c2ResCh)
 	go c1.Run()
 	go c2.Run()
 	for {
 		select {
-		case <-ticker.C:
-			fmt.Printf("C1: %s: %02d:%02d\n", c1.state, int(c1.time.Minutes()), int(math.Mod(c1.time.Seconds(), 60)))
-			fmt.Printf("C2: %s: %02d:%02d\n", c2.state, int(c2.time.Minutes()), int(math.Mod(c2.time.Seconds(), 60)))
+		case data := <-c1ResCh:
+			fmt.Println("C1: " + data)
+		case data := <-c2ResCh:
+			fmt.Println("C2: " + data)
 		case <-sigs:
-			ticker.Stop()
 			fmt.Println("Exiting...")
 			os.Exit(0)
 		}

--- a/main.go
+++ b/main.go
@@ -12,8 +12,10 @@ func main() {
 	c1ResCh := make(chan string)
 	c2ReqCh := make(chan string)
 	c2ResCh := make(chan string)
-	c1 := InitConnector("localhost:1350", c1ReqCh, c1ResCh)
-	c2 := InitConnector("localhost:1351", c2ReqCh, c2ResCh)
+	c1 := InitConnector(c1ReqCh, c1ResCh)
+	c2 := InitConnector(c2ReqCh, c2ResCh)
+	c1.Connect("localhost:1350")
+	c2.Connect("localhost:1351")
 	go c1.Run()
 	go c2.Run()
 	for {

--- a/util.go
+++ b/util.go
@@ -1,9 +1,0 @@
-package main
-
-import "fmt"
-import "time"
-import "math"
-
-func PrettyDuration(dur time.Duration) string {
-	return fmt.Sprintf("%02d:%02d", int(dur.Minutes()), int(math.Mod(dur.Seconds(), 60)))
-}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+import "time"
+import "math"
+
+func PrettyDuration(dur time.Duration) string {
+	return fmt.Sprintf("%02d:%02d", int(dur.Minutes()), int(math.Mod(dur.Seconds(), 60)))
+}

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,9 @@
+package util
+
+import "fmt"
+import "time"
+import "math"
+
+func PrettyDuration(dur time.Duration) string {
+	return fmt.Sprintf("%d:%02d", int(dur.Minutes()), int(math.Mod(dur.Seconds(), 60)))
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,37 @@
+package util
+
+import "testing"
+import "time"
+
+func TestUtil(t *testing.T) {
+	cases := []struct {
+		dur  time.Duration
+		want string
+	}{
+		{
+			time.Duration(60 * time.Second),
+			"1:00",
+		},
+		// Test negative durations because what the hell
+		{
+			time.Duration(-60 * time.Second),
+			"-1:00",
+		},
+		// Make sure no rounding shennanigans are happening
+		{
+			time.Duration(750 * time.Millisecond),
+			"0:00",
+		},
+		{
+			time.Duration(31 * time.Second),
+			"0:31",
+		},
+	}
+
+	for _, c := range cases {
+		got := PrettyDuration(c.dur)
+		if got != c.want {
+			t.Errorf("PrettyDuration(%q) == %q, want %q", c.dur, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Just in time to avoid too much confusion, Channels are now called Connectors and use (go) channels to communicate between Goroutines. Got that?
The main program now connects to two BAPS3 servers and prints lines as and when they come in, as opposed to printing the state every second.
