### PR TITLE
Cleanup and errors

### DIFF
--- a/baps3protocol/message.go
+++ b/baps3protocol/message.go
@@ -2,46 +2,124 @@ package baps3protocol
 
 import "strings"
 
+// MessageWord is a token representing a message word known to Bifrost.
+// While the BAPS3 API allows for arbitrarily many message words to exist, we
+// only handle a small, finite set of them.  For simplicity of later
+// comparison, we 'intern' the ones we know by converting them to a MessageWord
+// upon creation of the Message representing their parent message.
 type MessageWord int
 
 const (
 	/* Message word constants.
+	 *
 	 * When adding to this, also add the string equivalent to LookupRequest and
 	 * LookupResponse.
+	 *
+	 * Also note that the use of the same iota-run of numbers for requests,
+	 * responses and errors is intentional, because all three series of
+	 * message are conveyed in the same struct, parsed by the same
+	 * functions, and consequently the message word is referenced by code
+	 * with no understanding of whether the word pertains to a request, a
+	 * response, or something completely different.
 	 */
 
+	// BadWord denotes a message with an unknown and ill-formed word.
 	BadWord MessageWord = iota
 
 	// - Requests
+
+	// RqUnknown denotes a message with an unknown but valid request word.
 	RqUnknown
-	// -- Core
+
+	/* -- Core
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/core.html#requests
+	 */
+
+	// RqQuit denotes a 'quit' request message.
 	RqQuit
-	// -- PlayStop feature
+
+	/* -- PlayStop feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-playstop.html#requests
+	 */
+
+	// RqPlay denotes a 'play' request message.
 	RqPlay
+
+	// RqStop denotes a 'stop' request message.
 	RqStop
-	// -- FileLoad feature
+
+	/* -- FileLoad feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-fileload.html#requests
+	 */
+
+	// RqEject denotes an 'eject' request message.
 	RqEject
+
+	// RqLoad denotes a 'load' request message.
 	RqLoad
-	// -- Playlist feature
+
+	/* -- Playlist feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-playlist.html#requests
+	 */
+
+	// RqCount denotes a 'count' request message.
 	RqCount
+
+	// RqDequeue denotes a 'dequeue' request message.
 	RqDequeue
+
+	// RqEnqueue denotes an 'enqueue' request message.
 	RqEnqueue
+
+	// RqSelect denotes a 'select' request message.
 	RqSelect
 
 	// - Responses
+
+	// RsUnknown denotes a message with an unknown but valid response word.
 	RsUnknown
-	// -- Core
+
+	/* -- Core
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/core.html#responses
+	 */
+
+	// RsOk denotes a message with the 'OK' response.
 	RsOk
+
+	// RsFail denotes a message with the 'FAIL' response.
 	RsFail
+
+	// RsWhat denotes a message with the 'WHAT' response.
 	RsWhat
+
+	// RsOhai denotes a message with the 'OHAI' response.
 	RsOhai
+
+	// RsFeatures denotes a message with the 'FEATURES' response.
 	RsFeatures
+
+	// RsState denotes a message with the 'STATE' response.
 	RsState
-	// -- End feature
+
+	/* -- End feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-end.html#responses
+	 */
+
+	// RsEnd denotes a message with the 'END' response.
 	RsEnd
-	// -- FileLoad feature
+
+	/* -- FileLoad feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-fileload.html#responses
+	 */
+
+	// RsFile denotes a message with the 'FILE' response.
 	RsFile
-	// -- TimeReport feature
+
+	/* -- TimeReport feature
+	 * http://universityradioyork.github.io/baps3-spec/comms/internal/feature-timereport.html#responses
+	 */
+
+	// RsTime denotes a message with the 'TIME' response.
 	RsTime
 )
 
@@ -71,6 +149,7 @@ var wordStrings = []string{
 	"TIME",               // RsTime
 }
 
+// IsUnknown returns whether word represents a message word unknown to Bifrost.
 func (word MessageWord) IsUnknown() bool {
 	return word == BadWord || word == RqUnknown || word == RsUnknown
 }
@@ -79,6 +158,11 @@ func (word MessageWord) String() string {
 	return wordStrings[int(word)]
 }
 
+// LookupWord finds the equivalent MessageWord for a string.
+// If the message word is not known to Bifrost, it will check whether the word
+// is a valid request (all lowercase) or a valid response (all uppercase),
+// returning RqUnknown or RsUnknown respectively.  Failing this, it will return
+// BadWord.
 func LookupWord(word string) MessageWord {
 	// This is O(n) on the size of WordStrings, which is unfortunate, but
 	// probably ok.
@@ -102,6 +186,8 @@ type message struct {
 	args []string
 }
 
+// NewMessage creates and returns a new Message with the given message word.
+// The message will initially have no arguments; use AddArg to add arguments.
 func NewMessage(word MessageWord) *message {
 	m := new(message)
 	m.word = word

--- a/baps3protocol/message.go
+++ b/baps3protocol/message.go
@@ -218,6 +218,6 @@ func (m *Message) AsSlice() []string {
 // Pack outputs the given Message as raw bytes representing a BAPS3 message.
 // These bytes can be sent down a TCP connection to a BAPS3 server, providing
 // they are terminated using a line-feed character.
-func (m *Message) Pack() []byte {
+func (m *Message) Pack() ([]byte, error) {
 	return Pack(m.word.String(), m.args)
 }

--- a/baps3protocol/message.go
+++ b/baps3protocol/message.go
@@ -181,25 +181,33 @@ func LookupWord(word string) MessageWord {
 	return BadWord
 }
 
-type message struct {
+// Message is a structure representing a full BAPS3 message.
+// It is comprised of a word, which is stored as a MessageWord, and zero or
+// more string arguments.
+type Message struct {
 	word MessageWord
 	args []string
 }
 
 // NewMessage creates and returns a new Message with the given message word.
 // The message will initially have no arguments; use AddArg to add arguments.
-func NewMessage(word MessageWord) *message {
-	m := new(message)
+func NewMessage(word MessageWord) *Message {
+	m := new(Message)
 	m.word = word
 	return m
 }
 
-func (m *message) AddArg(arg string) *message {
+// AddArg adds the given argument to a Message in-place.
+// The given Message-pointer is returned, to allow for chaining.
+func (m *Message) AddArg(arg string) *Message {
 	m.args = append(m.args, arg)
 	return m
 }
 
-func (m *message) AsSlice() []string {
+// AsSlice outputs the given Message as a string slice.
+// The slice contains the string form of the Message's word in index 0, and
+// the arguments as index 1 upwards, if any.
+func (m *Message) AsSlice() []string {
 	slice := []string{m.word.String()}
 	for _, arg := range m.args {
 		slice = append(slice, arg)
@@ -207,6 +215,9 @@ func (m *message) AsSlice() []string {
 	return slice
 }
 
-func (m *message) Pack() []byte {
+// Pack outputs the given Message as raw bytes representing a BAPS3 message.
+// These bytes can be sent down a TCP connection to a BAPS3 server, providing
+// they are terminated using a line-feed character.
+func (m *Message) Pack() []byte {
 	return Pack(m.word.String(), m.args)
 }

--- a/baps3protocol/message_test.go
+++ b/baps3protocol/message_test.go
@@ -2,8 +2,8 @@ package baps3protocol
 
 import "testing"
 
-// cmp_words is defined in tokeniser_test.
-// TODO(CaptainHayashi): move cmp_words elsewhere?
+// cmpWords is defined in tokeniser_test.
+// TODO(CaptainHayashi): move cmpWords elsewhere?
 
 func TestMessageWord(t *testing.T) {
 	cases := []struct {
@@ -67,7 +67,7 @@ func TestMessage(t *testing.T) {
 
 	for _, c := range cases {
 		gotslice := c.msg.AsSlice()
-		if !cmp_words(gotslice, c.words) {
+		if !cmpWords(gotslice, c.words) {
 			t.Errorf("%q.ToSlice() == %q, want %q", c.msg, gotslice, c.words)
 		}
 	}

--- a/baps3protocol/message_test.go
+++ b/baps3protocol/message_test.go
@@ -45,7 +45,7 @@ func TestMessageWord(t *testing.T) {
 func TestMessage(t *testing.T) {
 	cases := []struct {
 		words []string
-		msg   *message
+		msg   *Message
 	}{
 		// Empty request
 		{[]string{"play"}, NewMessage(RqPlay)},

--- a/baps3protocol/packer.go
+++ b/baps3protocol/packer.go
@@ -8,9 +8,17 @@ import (
 
 // Pack a command word and 0+ args into a slice of bytes ready for sending.
 // Args will be single quote escaped if they contain ' " \ or whitespace
-func Pack(word string, args []string) []byte {
+// Pack may return an error if the resulting byte-slice is too large.
+func Pack(word string, args []string) (packed []byte, err error) {
+	packed, err = []byte{}, nil
+
 	output := new(bytes.Buffer)
-	output.WriteString(word)
+
+	_, err = output.WriteString(word)
+	if err != nil {
+		return
+	}
+
 	for _, a := range args {
 		// Escape arg if needed
 		for _, c := range a {
@@ -19,9 +27,15 @@ func Pack(word string, args []string) []byte {
 				break
 			}
 		}
-		output.WriteString(" " + a)
+
+		_, err = output.WriteString(" " + a)
+		if err != nil {
+			return
+		}
 	}
-	return output.Bytes()
+
+	packed = output.Bytes()
+	return
 }
 
 func escapeArgument(input string) (output string) {

--- a/baps3protocol/packer_test.go
+++ b/baps3protocol/packer_test.go
@@ -61,7 +61,10 @@ func TestPack(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		got := Pack(c.word, c.args)
+		got, err := Pack(c.word, c.args)
+		if err != nil {
+			t.Errorf("Pack(%q, %q) encountered error %q", c.word, c.args, err)
+		}
 		if !cmpByteSlices(c.want, got) {
 			t.Errorf("Pack(%q, %q) == %q, want %q", c.word, c.args, got, c.want)
 		}

--- a/baps3protocol/tokeniser.go
+++ b/baps3protocol/tokeniser.go
@@ -26,6 +26,7 @@ type Tokeniser struct {
 	word             *bytes.Buffer
 	words            []string
 	lines            [][]string
+	err              error
 }
 
 // NewTokeniser creates and returns a new, empty Tokeniser.
@@ -36,6 +37,7 @@ func NewTokeniser() *Tokeniser {
 	t.word = new(bytes.Buffer)
 	t.words = []string{}
 	t.lines = [][]string{}
+	t.err = nil
 	return t
 }
 
@@ -70,60 +72,98 @@ func (t *Tokeniser) endWord() {
 }
 
 // Tokenise feeds raw bytes into a Tokeniser.
+//
 // If the bytes include the ending of one or more command lines, those lines
 // shall be returned, as a slice of lines represented as slices of
 // word-strings.  Else, the slice shall be empty.
-func (t *Tokeniser) Tokenise(data []byte) [][]string {
+//
+// Tokenise may return an error if its current word gets over-full.  In this
+// case, lines will contain the lines it managed to tokenise before keeling
+// over, count will contain the number of bytes processed (including the byte
+// causing the error), and the tokeniser will remain in error until replaced or
+// the current word is ended.
+func (t *Tokeniser) Tokenise(data []byte) (lines [][]string, count uint64, err error) {
+	count = 0
 	for _, b := range data {
+		// Exit early if the current word has become over-full.  This
+		// lets the caller handle the error without silently masking it
+		// if we manage to progress.
+		if t.err != nil {
+			break
+		}
+
 		if t.escapeNextChar {
-			t.word.WriteByte(b)
+			t.put(b)
 			t.escapeNextChar = false
 			continue
 		}
 
 		switch t.currentQuoteType {
 		case none:
-			switch b {
-			case '\'':
-				t.currentQuoteType = single
-			case '"':
-				t.currentQuoteType = double
-			case '\\':
-				t.escapeNextChar = true
-			case '\n':
-				t.endLine()
-			default:
-				// Note that this will only check for ASCII
-				// whitespace, because we only pass it one byte
-				// and non-ASCII whitespace is >1 UTF-8 byte.
-				if unicode.IsSpace(rune(b)) {
-					t.endWord()
-				} else {
-					t.word.WriteByte(b)
-				}
-			}
-
+			t.tokeniseNoQuotes(b)
 		case single:
-			switch b {
-			case '\'':
-				t.currentQuoteType = none
-			default:
-				t.word.WriteByte(b)
-			}
-
+			t.tokeniseSingleQuotes(b)
 		case double:
-			switch b {
-			case '"':
-				t.currentQuoteType = none
-			case '\\':
-				t.escapeNextChar = true
-			default:
-				t.word.WriteByte(b)
-			}
+			t.tokeniseDoubleQuotes(b)
 		}
+
+		count++
 	}
 
-	lines := t.lines
-	t.lines = [][]string{}
-	return lines
+	lines, t.lines = t.lines, [][]string{}
+	err, t.err = t.err, nil
+
+	return
+}
+
+// tokeniseNoQuotes tokenises a single byte outside quote characters.
+func (t *Tokeniser) tokeniseNoQuotes(b byte) {
+	switch b {
+	case '\'':
+		t.currentQuoteType = single
+	case '"':
+		t.currentQuoteType = double
+	case '\\':
+		t.escapeNextChar = true
+	case '\n':
+		t.endLine()
+	default:
+		// Note that this will only check for ASCII
+		// whitespace, because we only pass it one byte
+		// and non-ASCII whitespace is >1 UTF-8 byte.
+		if unicode.IsSpace(rune(b)) {
+			t.endWord()
+		} else {
+			t.put(b)
+		}
+	}
+}
+
+// tokeniseSingleQuotes tokenises a single byte within single quotes.
+func (t *Tokeniser) tokeniseSingleQuotes(b byte) {
+	switch b {
+	case '\'':
+		t.currentQuoteType = none
+	default:
+		t.put(b)
+	}
+}
+
+// tokeniseDoubleQuotes tokenises a single byte within double quotes.
+func (t *Tokeniser) tokeniseDoubleQuotes(b byte) {
+	switch b {
+	case '"':
+		t.currentQuoteType = none
+	case '\\':
+		t.escapeNextChar = true
+	default:
+		t.put(b)
+	}
+}
+
+// put adds a byte to the Tokeniser's buffer.
+// If the buffer is too big, an error will be raised and propagated to the
+// Tokeniser's user.
+func (t *Tokeniser) put(b byte) {
+	t.err = t.word.WriteByte(b)
 }

--- a/baps3protocol/tokeniser.go
+++ b/baps3protocol/tokeniser.go
@@ -5,14 +5,21 @@ import (
 	"unicode"
 )
 
+// QuoteType represents one of the types of quoting used in the BAPS3 protocol.
 type QuoteType int
 
 const (
+	// None represents the state between quoted parts of a BAPS3 message.
 	None QuoteType = iota
+
+	// Single represents 'single quoted' parts of a BAPS3 message.
 	Single
+
+	// Double represents "double quoted" parts of a BAPS3 message.
 	Double
 )
 
+// Tokeniser holds the state of a BAPS3 protocol tokeniser.
 type Tokeniser struct {
 	escape_next_char bool
 	quote_type       QuoteType
@@ -21,6 +28,7 @@ type Tokeniser struct {
 	lines            [][]string
 }
 
+// NewTokeniser creates and returns a new, empty Tokeniser.
 func NewTokeniser() *Tokeniser {
 	t := new(Tokeniser)
 	t.escape_next_char = false
@@ -61,6 +69,10 @@ func (t *Tokeniser) endWord() {
 	t.word.Truncate(0)
 }
 
+// Tokenise feeds raw bytes into a Tokeniser.
+// If the bytes include the ending of one or more command lines, those lines
+// shall be returned, as a slice of lines represented as slices of
+// word-strings.  Else, the slice shall be empty.
 func (t *Tokeniser) Tokenise(data []byte) [][]string {
 	for _, b := range data {
 		if t.escape_next_char {

--- a/baps3protocol/tokeniser.go
+++ b/baps3protocol/tokeniser.go
@@ -21,8 +21,8 @@ const (
 
 // Tokeniser holds the state of a BAPS3 protocol tokeniser.
 type Tokeniser struct {
-	escape_next_char bool
-	quote_type       quoteType
+	escapeNextChar   bool
+	currentQuoteType quoteType
 	word             *bytes.Buffer
 	words            []string
 	lines            [][]string
@@ -31,8 +31,8 @@ type Tokeniser struct {
 // NewTokeniser creates and returns a new, empty Tokeniser.
 func NewTokeniser() *Tokeniser {
 	t := new(Tokeniser)
-	t.escape_next_char = false
-	t.quote_type = none
+	t.escapeNextChar = false
+	t.currentQuoteType = none
 	t.word = new(bytes.Buffer)
 	t.words = []string{}
 	t.lines = [][]string{}
@@ -75,21 +75,21 @@ func (t *Tokeniser) endWord() {
 // word-strings.  Else, the slice shall be empty.
 func (t *Tokeniser) Tokenise(data []byte) [][]string {
 	for _, b := range data {
-		if t.escape_next_char {
+		if t.escapeNextChar {
 			t.word.WriteByte(b)
-			t.escape_next_char = false
+			t.escapeNextChar = false
 			continue
 		}
 
-		switch t.quote_type {
+		switch t.currentQuoteType {
 		case none:
 			switch b {
 			case '\'':
-				t.quote_type = single
+				t.currentQuoteType = single
 			case '"':
-				t.quote_type = double
+				t.currentQuoteType = double
 			case '\\':
-				t.escape_next_char = true
+				t.escapeNextChar = true
 			case '\n':
 				t.endLine()
 			default:
@@ -106,7 +106,7 @@ func (t *Tokeniser) Tokenise(data []byte) [][]string {
 		case single:
 			switch b {
 			case '\'':
-				t.quote_type = none
+				t.currentQuoteType = none
 			default:
 				t.word.WriteByte(b)
 			}
@@ -114,9 +114,9 @@ func (t *Tokeniser) Tokenise(data []byte) [][]string {
 		case double:
 			switch b {
 			case '"':
-				t.quote_type = none
+				t.currentQuoteType = none
 			case '\\':
-				t.escape_next_char = true
+				t.escapeNextChar = true
 			default:
 				t.word.WriteByte(b)
 			}

--- a/baps3protocol/tokeniser.go
+++ b/baps3protocol/tokeniser.go
@@ -5,24 +5,24 @@ import (
 	"unicode"
 )
 
-// QuoteType represents one of the types of quoting used in the BAPS3 protocol.
-type QuoteType int
+// quoteType represents one of the types of quoting used in the BAPS3 protocol.
+type quoteType int
 
 const (
-	// None represents the state between quoted parts of a BAPS3 message.
-	None QuoteType = iota
+	// none represents the state between quoted parts of a BAPS3 message.
+	none quoteType = iota
 
-	// Single represents 'single quoted' parts of a BAPS3 message.
-	Single
+	// single represents 'single quoted' parts of a BAPS3 message.
+	single
 
-	// Double represents "double quoted" parts of a BAPS3 message.
-	Double
+	// double represents "double quoted" parts of a BAPS3 message.
+	double
 )
 
 // Tokeniser holds the state of a BAPS3 protocol tokeniser.
 type Tokeniser struct {
 	escape_next_char bool
-	quote_type       QuoteType
+	quote_type       quoteType
 	word             *bytes.Buffer
 	words            []string
 	lines            [][]string
@@ -32,7 +32,7 @@ type Tokeniser struct {
 func NewTokeniser() *Tokeniser {
 	t := new(Tokeniser)
 	t.escape_next_char = false
-	t.quote_type = None
+	t.quote_type = none
 	t.word = new(bytes.Buffer)
 	t.words = []string{}
 	t.lines = [][]string{}
@@ -82,12 +82,12 @@ func (t *Tokeniser) Tokenise(data []byte) [][]string {
 		}
 
 		switch t.quote_type {
-		case None:
+		case none:
 			switch b {
 			case '\'':
-				t.quote_type = Single
+				t.quote_type = single
 			case '"':
-				t.quote_type = Double
+				t.quote_type = double
 			case '\\':
 				t.escape_next_char = true
 			case '\n':
@@ -103,18 +103,18 @@ func (t *Tokeniser) Tokenise(data []byte) [][]string {
 				}
 			}
 
-		case Single:
+		case single:
 			switch b {
 			case '\'':
-				t.quote_type = None
+				t.quote_type = none
 			default:
 				t.word.WriteByte(b)
 			}
 
-		case Double:
+		case double:
 			switch b {
 			case '"':
-				t.quote_type = None
+				t.quote_type = none
 			case '\\':
 				t.escape_next_char = true
 			default:

--- a/baps3protocol/tokeniser_test.go
+++ b/baps3protocol/tokeniser_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-func cmp_lines(a [][]string, b [][]string) bool {
+func cmpLines(a [][]string, b [][]string) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
 	for i, aline := range a {
-		if !cmp_words(aline, b[i]) {
+		if !cmpWords(aline, b[i]) {
 			return false
 		}
 	}
@@ -18,7 +18,7 @@ func cmp_lines(a [][]string, b [][]string) bool {
 	return true
 }
 
-func cmp_words(a []string, b []string) bool {
+func cmpWords(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -132,7 +132,7 @@ func TestTokenise(t *testing.T) {
 	for _, c := range cases {
 		tok := NewTokeniser()
 		got := tok.Tokenise([]byte(c.in))
-		if !cmp_lines(got, c.want) {
+		if !cmpLines(got, c.want) {
 			t.Errorf("Tokenise(%q) == %q, want %q", c.in, got, c.want)
 		}
 	}

--- a/baps3protocol/tokeniser_test.go
+++ b/baps3protocol/tokeniser_test.go
@@ -131,7 +131,10 @@ func TestTokenise(t *testing.T) {
 
 	for _, c := range cases {
 		tok := NewTokeniser()
-		got := tok.Tokenise([]byte(c.in))
+		got, _, err := tok.Tokenise([]byte(c.in))
+		if err != nil {
+			t.Errorf("Tokenise(%q) gave error %q", c.in, err)
+		}
 		if !cmpLines(got, c.want) {
 			t.Errorf("Tokenise(%q) == %q, want %q", c.in, got, c.want)
 		}

--- a/connector.go
+++ b/connector.go
@@ -62,7 +62,13 @@ func (c *Connector) Run() {
 			if err != nil {
 				errCh <- err
 			}
-			lineCh <- c.tokeniser.Tokenise(data)
+			// TODO(CaptainHayashi): more robust handling of an
+			// error from Tokenise?
+			lines, _, err := c.tokeniser.Tokenise(data)
+			if err != nil {
+				errCh <- err
+			}
+			lineCh <- lines
 		}
 	}(lineCh, errCh)
 

--- a/connector.go
+++ b/connector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+// Connector is a struct containing the internal state of a BAPS3 connector.
 type Connector struct {
 	state     string
 	time      time.Duration
@@ -23,6 +24,10 @@ type Connector struct {
 	logger    *log.Logger
 }
 
+// InitConnector creates and returns a Connector.
+// The returned Connector shall have the given name, send responses through the
+// response channel resCh, report termination via the wait group waitGroup, and
+// log to logger.
 func InitConnector(name string, resCh chan string, waitGroup *sync.WaitGroup, logger *log.Logger) *Connector {
 	c := new(Connector)
 	c.tokeniser = baps3protocol.NewTokeniser()
@@ -34,6 +39,7 @@ func InitConnector(name string, resCh chan string, waitGroup *sync.WaitGroup, lo
 	return c
 }
 
+// Connect connects an existing Connector to the BAPS3 server at hostport.
 func (c *Connector) Connect(hostport string) {
 	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
@@ -43,6 +49,7 @@ func (c *Connector) Connect(hostport string) {
 	c.buf = bufio.NewReader(c.conn)
 }
 
+// Run sets the given Connector off running.
 func (c *Connector) Run() {
 	lineCh := make(chan [][]string, 3)
 	errCh := make(chan error)

--- a/connector.go
+++ b/connector.go
@@ -1,13 +1,14 @@
 package main
 
-import "time"
-import "net"
-import "bufio"
-import "sync"
-import "log"
-
-import "github.com/UniversityRadioYork/bifrost/baps3protocol"
-import "github.com/UniversityRadioYork/bifrost/util"
+import (
+	"bufio"
+	"github.com/UniversityRadioYork/bifrost/baps3protocol"
+	"github.com/UniversityRadioYork/bifrost/util"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
 
 type Connector struct {
 	state     string

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ type server struct {
 	Hostport string
 }
 
+// Config is a struct containing the configuration for an instance of Bifrost.
 type Config struct {
 	Servers map[string]server
 }

--- a/main.go
+++ b/main.go
@@ -1,14 +1,15 @@
 package main
 
-import "os"
-import "os/signal"
-import "syscall"
-import "fmt"
-import "log"
-import "io/ioutil"
-import "sync"
-
-import "github.com/BurntSushi/toml"
+import (
+	"fmt"
+	"github.com/BurntSushi/toml"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
 
 type server struct {
 	Hostport string

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// PrettyDuration pretty-prints a duration in the form minutes:seconds.
+// The seconds part is zero-padded; the minutes part is not.
 func PrettyDuration(dur time.Duration) string {
 	return fmt.Sprintf("%d:%02d", int(dur.Minutes()), int(math.Mod(dur.Seconds(), 60)))
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,8 +1,10 @@
 package util
 
-import "fmt"
-import "time"
-import "math"
+import (
+	"fmt"
+	"math"
+	"time"
+)
 
 func PrettyDuration(dur time.Duration) string {
 	return fmt.Sprintf("%d:%02d", int(dur.Minutes()), int(math.Mod(dur.Seconds(), 60)))

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,7 +1,9 @@
 package util
 
-import "testing"
-import "time"
+import (
+	"testing"
+	"time"
+)
 
 func TestUtil(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
This does the following:
- Makes some things private that were unnecessarily public, and vice versa;
- Adds comments to most public items;
- Changes to camelCase throughout;
- Makes the Tokeniser and Packer return errors.  This is because the byte buffer used in both can return errors itself if it grows too large.  Tests and main code updated accordingly.
